### PR TITLE
2020.1 g11 sya#57

### DIFF
--- a/sya/src/config/upload.ts
+++ b/sya/src/config/upload.ts
@@ -31,7 +31,7 @@ export default {
     storage: multer.diskStorage({
       destination: tmpFolder,
       filename(request, file, callback) {
-        const fileHash = crypto.randomBytes(10).toString('HEX');
+        const fileHash = crypto.randomBytes(10).toString('hex');
         const fileName = `${fileHash}-${file.originalname}`;
 
         return callback(null, fileName);

--- a/sya/src/modules/employees/infra/http/controllers/EmployeesController.ts
+++ b/sya/src/modules/employees/infra/http/controllers/EmployeesController.ts
@@ -6,7 +6,8 @@ import ListAllEmployeesService from '@modules/employees/services/ListAllEmployee
 
 export default class EmployeesController {
   public async create(request: Request, response: Response): Promise<Response> {
-    const { name, user_id } = request.body;
+    const { name } = request.body;
+    const user_id = request.user.id;
 
     const createEmployee = container.resolve(CreateEmployeeService);
 

--- a/sya/src/modules/works/dtos/ICreateWorkDTO.ts
+++ b/sya/src/modules/works/dtos/ICreateWorkDTO.ts
@@ -1,4 +1,5 @@
 export default interface ICreateWorkDTO {
+  user_id: string;
   name: string;
   price: number;
   duration: string;

--- a/sya/src/modules/works/dtos/ICreateWorkDTO.ts
+++ b/sya/src/modules/works/dtos/ICreateWorkDTO.ts
@@ -1,0 +1,5 @@
+export default interface ICreateWorkDTO {
+  name: string;
+  price: number;
+  duration: string;
+}

--- a/sya/src/modules/works/infra/http/controllers/WorksController.ts
+++ b/sya/src/modules/works/infra/http/controllers/WorksController.ts
@@ -6,6 +6,7 @@ import { classToClass } from 'class-transformer';
 export default class WorksController {
   public async create(request: Request, response: Response): Promise<Response> {
     const { name, price, duration } = request.body;
+    const user_id = request.user.id;
 
     const createWork = container.resolve(CreateWorkService);
 
@@ -13,6 +14,7 @@ export default class WorksController {
       name,
       price,
       duration,
+      user_id,
     });
 
     return response.json(classToClass(work));

--- a/sya/src/modules/works/infra/http/controllers/WorksController.ts
+++ b/sya/src/modules/works/infra/http/controllers/WorksController.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+import CreateWorkService from '@modules/works/services/CreateWorkService';
+import { classToClass } from 'class-transformer';
+
+export default class WorksController {
+  public async create(request: Request, response: Response): Promise<Response> {
+    const { name, price, duration } = request.body;
+
+    const createWork = container.resolve(CreateWorkService);
+
+    const work = await createWork.execute({
+      name,
+      price,
+      duration,
+    });
+
+    return response.json(classToClass(work));
+  }
+}

--- a/sya/src/modules/works/infra/http/routes/works.routes.ts
+++ b/sya/src/modules/works/infra/http/routes/works.routes.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { celebrate, Segments, Joi } from 'celebrate';
+import WorksController from '@modules/works/infra/http/controllers/WorksController';
+import ensureAuthenticated from '@shared/infra/http/middlewares/ensureAuthenticated';
+
+const workRouter = Router();
+
+const workController = new WorksController();
+workRouter.use(ensureAuthenticated);
+workRouter.post(
+  '/',
+  celebrate({
+    [Segments.BODY]: {
+      name: Joi.string().required(),
+      price: Joi.number().required(),
+      duration: Joi.string().required(),
+    },
+  }),
+  workController.create
+);
+
+export default workRouter;

--- a/sya/src/modules/works/infra/typeorm/entities/Work.ts
+++ b/sya/src/modules/works/infra/typeorm/entities/Work.ts
@@ -1,9 +1,12 @@
+import User from '@modules/users/infra/typeorm/entities/User';
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
 
 @Entity('works')
@@ -23,6 +26,13 @@ class Work {
     length: 100,
   })
   duration: string;
+
+  @Column()
+  user_id: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
 
   @CreateDateColumn()
   created_at: Date;

--- a/sya/src/modules/works/infra/typeorm/entities/Work.ts
+++ b/sya/src/modules/works/infra/typeorm/entities/Work.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('works')
+class Work {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({
+    length: 100,
+  })
+  name: string;
+
+  @Column({
+    length: 10,
+  })
+  price: number;
+
+  @Column({
+    length: 100,
+  })
+  duration: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}
+
+export default Work;

--- a/sya/src/modules/works/infra/typeorm/entities/Work.ts
+++ b/sya/src/modules/works/infra/typeorm/entities/Work.ts
@@ -16,9 +16,7 @@ class Work {
   })
   name: string;
 
-  @Column({
-    length: 10,
-  })
+  @Column()
   price: number;
 
   @Column({

--- a/sya/src/modules/works/infra/typeorm/repositories/WorkRepository.ts
+++ b/sya/src/modules/works/infra/typeorm/repositories/WorkRepository.ts
@@ -1,0 +1,25 @@
+import ICreateWorkDTO from '@modules/works/dtos/ICreateWorkDTO';
+import IWorkRepository from '@modules/works/repositories/IWorkRepository';
+import { getRepository, Repository } from 'typeorm';
+import Work from '../entities/Work';
+
+class WorkRepository implements IWorkRepository {
+  private ormRepository: Repository<Work>;
+
+  constructor() {
+    this.ormRepository = getRepository(Work);
+  }
+
+  public findById(id: string): Promise<Work | undefined> {
+    const findWork = this.ormRepository.findOne(id);
+    return findWork;
+  }
+
+  public async create(workData: ICreateWorkDTO): Promise<Work> {
+    const work = this.ormRepository.create(workData);
+    await this.ormRepository.save(work);
+    return work;
+  }
+}
+
+export default WorkRepository;

--- a/sya/src/modules/works/infra/typeorm/repositories/WorkRepository.ts
+++ b/sya/src/modules/works/infra/typeorm/repositories/WorkRepository.ts
@@ -20,6 +20,11 @@ class WorkRepository implements IWorkRepository {
     await this.ormRepository.save(work);
     return work;
   }
+
+  public findAllWorks(user_id: string): Promise<Work[]> {
+    const findWorks = this.ormRepository.find({ where: { user_id } });
+    return findWorks;
+  }
 }
 
 export default WorkRepository;

--- a/sya/src/modules/works/repositories/IWorkRepository.ts
+++ b/sya/src/modules/works/repositories/IWorkRepository.ts
@@ -1,0 +1,7 @@
+import Work from '@modules/works/infra/typeorm/entities/Work';
+import ICreateWorkDTO from '@modules/works/dtos/ICreateWorkDTO';
+
+export default interface IWorkRepository {
+  findById(id: string): Promise<Work | undefined>;
+  create(WorkData: ICreateWorkDTO): Promise<Work>;
+}

--- a/sya/src/modules/works/repositories/IWorkRepository.ts
+++ b/sya/src/modules/works/repositories/IWorkRepository.ts
@@ -4,4 +4,5 @@ import ICreateWorkDTO from '@modules/works/dtos/ICreateWorkDTO';
 export default interface IWorkRepository {
   findById(id: string): Promise<Work | undefined>;
   create(WorkData: ICreateWorkDTO): Promise<Work>;
+  findAllWorks(user_id: string): Promise<Work[]>;
 }

--- a/sya/src/modules/works/services/CreateWorkService.ts
+++ b/sya/src/modules/works/services/CreateWorkService.ts
@@ -10,11 +10,17 @@ class CreateWorkService {
     private worksRepository: IWorkRepository
   ) {}
 
-  async execute({ name, price, duration }: ICreateWorkDTO): Promise<Work> {
+  async execute({
+    name,
+    price,
+    duration,
+    user_id,
+  }: ICreateWorkDTO): Promise<Work> {
     const work = await this.worksRepository.create({
       name,
       price,
       duration,
+      user_id,
     });
     return work;
   }

--- a/sya/src/modules/works/services/CreateWorkService.ts
+++ b/sya/src/modules/works/services/CreateWorkService.ts
@@ -1,0 +1,23 @@
+import { injectable, inject } from 'tsyringe';
+import Work from '../infra/typeorm/entities/Work';
+import IWorkRepository from '../repositories/IWorkRepository';
+import ICreateWorkDTO from '../dtos/ICreateWorkDTO';
+
+@injectable()
+class CreateWorkService {
+  constructor(
+    @inject('WorkRepository')
+    private worksRepository: IWorkRepository
+  ) {}
+
+  async execute({ name, price, duration }: ICreateWorkDTO): Promise<Work> {
+    const work = await this.worksRepository.create({
+      name,
+      price,
+      duration,
+    });
+    return work;
+  }
+}
+
+export default CreateWorkService;

--- a/sya/src/shared/container/index.ts
+++ b/sya/src/shared/container/index.ts
@@ -6,9 +6,12 @@ import UserRepository from '@modules/users/infra/typeorm/repositories/UserReposi
 import IUserRepository from '@modules/users/repositories/IUserRepository';
 import EmployeeRepository from '@modules/employees/infra/typeorm/repositories/EmployeeRepository';
 import IEmployeeRepository from '@modules/employees/repositories/IEmployeeRepository';
+import WorkRepository from '@modules/works/infra/typeorm/repositories/WorkRepository';
+import IWorkRepository from '@modules/works/repositories/IWorkRepository';
 
 container.registerSingleton<IUserRepository>('UserRepository', UserRepository);
 container.registerSingleton<IEmployeeRepository>(
   'EmployeeRepository',
   EmployeeRepository
 );
+container.registerSingleton<IWorkRepository>('WorkRepository', WorkRepository);

--- a/sya/src/shared/infra/http/routes/index.ts
+++ b/sya/src/shared/infra/http/routes/index.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import userRouter from '@modules/users/infra/http/routes/users.routes';
 import employeesRouter from '@modules/employees/infra/http/routes/employees.routes';
 import sessionsRouter from '@modules/users/infra/http/routes/sessions.routes';
+import worksRouter from '@modules/works/infra/http/routes/works.routes';
 
 const routes = Router();
 
 routes.use('/users', userRouter);
 routes.use('/sessions', sessionsRouter);
 routes.use('/employees', employeesRouter);
+routes.use('/works', worksRouter);
 
 export default routes;

--- a/sya/src/shared/infra/typeorm/migrations/1604460337445-CreateWorks.ts
+++ b/sya/src/shared/infra/typeorm/migrations/1604460337445-CreateWorks.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner, Table } from 'typeorm';
 
 // eslint-disable-next-line import/prefer-default-export
-export class CreateWorks1604460337445 implements MigrationInterface {
+export default class CreateWorks1604460337445 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createTable(
       new Table({

--- a/sya/src/shared/infra/typeorm/migrations/1604460337445-CreateWorks.ts
+++ b/sya/src/shared/infra/typeorm/migrations/1604460337445-CreateWorks.ts
@@ -1,11 +1,11 @@
 import { MigrationInterface, QueryRunner, Table } from 'typeorm';
 
 // eslint-disable-next-line import/prefer-default-export
-export class CreateEmployees1603319919264 implements MigrationInterface {
+export class CreateWorks1604460337445 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createTable(
       new Table({
-        name: 'employees',
+        name: 'works',
         columns: [
           {
             name: 'id',
@@ -19,8 +19,12 @@ export class CreateEmployees1603319919264 implements MigrationInterface {
             type: 'varchar',
           },
           {
-            name: 'user_id',
-            type: 'uuid',
+            name: 'price',
+            type: 'varchar',
+          },
+          {
+            name: 'duration',
+            type: 'varchar',
           },
           {
             name: 'created_at',
@@ -33,20 +37,11 @@ export class CreateEmployees1603319919264 implements MigrationInterface {
             default: 'now()',
           },
         ],
-        foreignKeys: [
-          {
-            name: 'EmployeeUser',
-            referencedTableName: 'users',
-            referencedColumnNames: ['id'],
-            columnNames: ['user_id'],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
-        ],
       })
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.dropTable('employees');
   }

--- a/sya/src/shared/infra/typeorm/migrations/1604696995496-AddUserForeignKeyToWorks.ts
+++ b/sya/src/shared/infra/typeorm/migrations/1604696995496-AddUserForeignKeyToWorks.ts
@@ -1,0 +1,36 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableForeignKey,
+} from 'typeorm';
+
+export default class AddUserForeignKeyToWorks1604696995496
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'works',
+      new TableColumn({
+        name: 'user_id',
+        type: 'uuid',
+        isNullable: true,
+      })
+    );
+    await queryRunner.createForeignKey(
+      'works',
+      new TableForeignKey({
+        name: 'WorkUser',
+        columnNames: ['user_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'SET NULL ',
+        onUpdate: 'CASCADE',
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('works', 'WorkUser');
+    await queryRunner.dropColumn('works', 'user_id');
+  }
+}


### PR DESCRIPTION
## Nome
Cadastrar Serviço - Backend

## Descrição
Criar módulo de criação de serviço no Backend, pelo prestador de serviços.

## Objetivo
A baixa conseguimos ver os parâmetros utilizados na requisição e a rota utilizada:
![Screenshot from 2020-11-09 18-58-31](https://user-images.githubusercontent.com/42192277/98601456-d73a0800-22bd-11eb-8e16-a130646e45e5.png)


## Critérios de aceitação
- [x] Desenvolver funcionalidade para que seja possível criar as informações do serviço no banco de dados;
- [x] Desenvolver rota na API para realizar o envio das alterações;
- [x] Verificar se as inclusões para os campos são válidas;
